### PR TITLE
PVEfficiency 0.165 -> 0.18

### DIFF
--- a/scripts/white_xlsx_to_json.py
+++ b/scripts/white_xlsx_to_json.py
@@ -12,9 +12,9 @@ BTA_TO_ATEMP = 0.9
 # factor, we transform using a really low COP
 A_LOW_COP = 2.0
 
-# Peak radiation for an hour in Varberg in 2019 was 872.7 W/m2. Assuming 16.5% PV efficiency, we calculate the peak PV
+# Peak radiation for an hour in Varberg in 2019 was 872.7 W/m2. Assuming 18% PV efficiency, we calculate the peak PV
 # production per square meter as:
-MAX_KW_PV_PROD_PER_SQM = 872.7 * 0.165 / 1000.0
+MAX_KW_PV_PROD_PER_SQM = 872.7 * 0.18 / 1000.0
 
 DATA_DIR = '../tradingplatformpoc/data/'
 

--- a/tests/test_app_functions.py
+++ b/tests/test_app_functions.py
@@ -47,7 +47,7 @@ class TestAppFunctions(TestCase):
         # PVEfficiency, min value: 0.01, max value: 0.99
         self.assertIsNotNone(config_data_param_screening({'AreaInfo': {'PVEfficiency': -0.1}}))
         self.assertIsNotNone(config_data_param_screening({'AreaInfo': {'PVEfficiency': 2.0}}))
-        self.assertIsNone(config_data_param_screening({'AreaInfo': {'PVEfficiency': 0.165}}))
+        self.assertIsNone(config_data_param_screening({'AreaInfo': {'PVEfficiency': 0.18}}))
 
     def test_config_data_agent_screening(self):
         """Test of agent input check."""

--- a/tradingplatformpoc/config/area_info_specs.json
+++ b/tradingplatformpoc/config/area_info_specs.json
@@ -16,7 +16,7 @@
         "min_value": 0.01,
         "max_value": 0.99,
         "format": "%.3f",
-        "default": 0.165,
+        "default": 0.18,
         "step": 0.005,
         "help": "A number specifying the efficiency of solar panels in the microgrid. Number must be between 0 and 1, and is typically in the 0.15-0.25 range"
     },

--- a/tradingplatformpoc/config/default_agents.json
+++ b/tradingplatformpoc/config/default_agents.json
@@ -12,7 +12,7 @@
 		"BoosterPumpMaxInput": 14.0,
 		"BoosterPumpMaxOutput": 28.0,
 		"HeatPumpForCooling": false,
-		"BatteryCapacity": 126.0,
+		"BatteryCapacity": 137.0,
 		"AccumulatorTankCapacity": 375.0,
 		"FractionUsedForBITES": 0.0
 	},
@@ -29,7 +29,7 @@
 		"BoosterPumpMaxInput": 12.0,
 		"BoosterPumpMaxOutput": 24.0,
 		"HeatPumpForCooling": false,
-		"BatteryCapacity": 87.0,
+		"BatteryCapacity": 95.0,
 		"AccumulatorTankCapacity": 337.5,
 		"FractionUsedForBITES": 0.0
 	},
@@ -46,7 +46,7 @@
 		"BoosterPumpMaxInput": 14.0,
 		"BoosterPumpMaxOutput": 28.0,
 		"HeatPumpForCooling": false,
-		"BatteryCapacity": 100.0,
+		"BatteryCapacity": 109.0,
 		"AccumulatorTankCapacity": 375.0,
 		"FractionUsedForBITES": 0.0
 	},
@@ -63,7 +63,7 @@
 		"BoosterPumpMaxInput": 12.0,
 		"BoosterPumpMaxOutput": 24.0,
 		"HeatPumpForCooling": false,
-		"BatteryCapacity": 77.0,
+		"BatteryCapacity": 84.0,
 		"AccumulatorTankCapacity": 337.5,
 		"FractionUsedForBITES": 0.0
 	},
@@ -80,7 +80,7 @@
 		"BoosterPumpMaxInput": 12.0,
 		"BoosterPumpMaxOutput": 24.0,
 		"HeatPumpForCooling": false,
-		"BatteryCapacity": 93.0,
+		"BatteryCapacity": 101.0,
 		"AccumulatorTankCapacity": 337.5,
 		"FractionUsedForBITES": 0.0
 	},
@@ -97,7 +97,7 @@
 		"BoosterPumpMaxInput": 10.5,
 		"BoosterPumpMaxOutput": 21.0,
 		"HeatPumpForCooling": false,
-		"BatteryCapacity": 83.0,
+		"BatteryCapacity": 90.0,
 		"AccumulatorTankCapacity": 300.0,
 		"FractionUsedForBITES": 0.0
 	},
@@ -114,7 +114,7 @@
 		"BoosterPumpMaxInput": 10.5,
 		"BoosterPumpMaxOutput": 21.0,
 		"HeatPumpForCooling": false,
-		"BatteryCapacity": 87.0,
+		"BatteryCapacity": 95.0,
 		"AccumulatorTankCapacity": 300.0,
 		"FractionUsedForBITES": 0.0
 	},
@@ -131,7 +131,7 @@
 		"BoosterPumpMaxInput": 17.0,
 		"BoosterPumpMaxOutput": 34.0,
 		"HeatPumpForCooling": false,
-		"BatteryCapacity": 142.0,
+		"BatteryCapacity": 155.0,
 		"AccumulatorTankCapacity": 450.0,
 		"FractionUsedForBITES": 0.0
 	},
@@ -148,7 +148,7 @@
 		"BoosterPumpMaxInput": 12.0,
 		"BoosterPumpMaxOutput": 24.0,
 		"HeatPumpForCooling": false,
-		"BatteryCapacity": 93.0,
+		"BatteryCapacity": 101.0,
 		"AccumulatorTankCapacity": 337.5,
 		"FractionUsedForBITES": 0.0
 	},
@@ -165,7 +165,7 @@
 		"BoosterPumpMaxInput": 12.0,
 		"BoosterPumpMaxOutput": 24.0,
 		"HeatPumpForCooling": false,
-		"BatteryCapacity": 83.0,
+		"BatteryCapacity": 91.0,
 		"AccumulatorTankCapacity": 337.5,
 		"FractionUsedForBITES": 0.0
 	},
@@ -182,7 +182,7 @@
 		"BoosterPumpMaxInput": 7.0,
 		"BoosterPumpMaxOutput": 14.0,
 		"HeatPumpForCooling": false,
-		"BatteryCapacity": 54.0,
+		"BatteryCapacity": 59.0,
 		"AccumulatorTankCapacity": 225.0,
 		"FractionUsedForBITES": 0.0
 	},
@@ -199,7 +199,7 @@
 		"BoosterPumpMaxInput": 12.0,
 		"BoosterPumpMaxOutput": 24.0,
 		"HeatPumpForCooling": false,
-		"BatteryCapacity": 107.0,
+		"BatteryCapacity": 117.0,
 		"AccumulatorTankCapacity": 337.5,
 		"FractionUsedForBITES": 0.0
 	},
@@ -216,7 +216,7 @@
 		"BoosterPumpMaxInput": 12.0,
 		"BoosterPumpMaxOutput": 24.0,
 		"HeatPumpForCooling": false,
-		"BatteryCapacity": 93.0,
+		"BatteryCapacity": 101.0,
 		"AccumulatorTankCapacity": 337.5,
 		"FractionUsedForBITES": 0.0
 	},
@@ -233,7 +233,7 @@
 		"BoosterPumpMaxInput": 10.5,
 		"BoosterPumpMaxOutput": 21.0,
 		"HeatPumpForCooling": false,
-		"BatteryCapacity": 65.0,
+		"BatteryCapacity": 71.0,
 		"AccumulatorTankCapacity": 300.0,
 		"FractionUsedForBITES": 0.0
 	},
@@ -250,7 +250,7 @@
 		"BoosterPumpMaxInput": 7.0,
 		"BoosterPumpMaxOutput": 14.0,
 		"HeatPumpForCooling": false,
-		"BatteryCapacity": 51.0,
+		"BatteryCapacity": 56.0,
 		"AccumulatorTankCapacity": 225.0,
 		"FractionUsedForBITES": 0.0
 	},
@@ -267,7 +267,7 @@
 		"BoosterPumpMaxInput": 7.0,
 		"BoosterPumpMaxOutput": 14.0,
 		"HeatPumpForCooling": false,
-		"BatteryCapacity": 43.0,
+		"BatteryCapacity": 47.0,
 		"AccumulatorTankCapacity": 225.0,
 		"FractionUsedForBITES": 0.0
 	},
@@ -284,7 +284,7 @@
 		"BoosterPumpMaxInput": 7.0,
 		"BoosterPumpMaxOutput": 14.0,
 		"HeatPumpForCooling": false,
-		"BatteryCapacity": 63.0,
+		"BatteryCapacity": 68.0,
 		"AccumulatorTankCapacity": 225.0,
 		"FractionUsedForBITES": 0.0
 	},
@@ -301,7 +301,7 @@
 		"BoosterPumpMaxInput": 17.0,
 		"BoosterPumpMaxOutput": 34.0,
 		"HeatPumpForCooling": false,
-		"BatteryCapacity": 134.0,
+		"BatteryCapacity": 146.0,
 		"AccumulatorTankCapacity": 450.0,
 		"FractionUsedForBITES": 0.0
 	},
@@ -318,7 +318,7 @@
 		"BoosterPumpMaxInput": 12.0,
 		"BoosterPumpMaxOutput": 24.0,
 		"HeatPumpForCooling": false,
-		"BatteryCapacity": 97.0,
+		"BatteryCapacity": 106.0,
 		"AccumulatorTankCapacity": 337.5,
 		"FractionUsedForBITES": 0.0
 	},
@@ -335,7 +335,7 @@
 		"BoosterPumpMaxInput": 12.0,
 		"BoosterPumpMaxOutput": 24.0,
 		"HeatPumpForCooling": false,
-		"BatteryCapacity": 81.0,
+		"BatteryCapacity": 89.0,
 		"AccumulatorTankCapacity": 337.5,
 		"FractionUsedForBITES": 0.0
 	},


### PR DESCRIPTION
Raised default PV efficiency from 16.5% to 18%, after discussion in today's meeting.

Since we want the default battery sizes to correspond to maximum PV production for the agent, changing the PV efficiency also increases the desired default battery sizes.