### PR TITLE
Enabling "Bakery"

### DIFF
--- a/tests/test_app_functions.py
+++ b/tests/test_app_functions.py
@@ -11,7 +11,7 @@ class TestAppFunctions(TestCase):
                     "Resource": "ELECTRICITY", "TransferRate": 5.0}
     mock_grid_he = {"Type": "GridAgent", "Name": "HeatingGridAgent",
                     "Resource": "HIGH_TEMP_HEAT", "TransferRate": 5.0}
-    mock_bakery = {"Type": "HeatProducerAgent", "Name": "HPA", "Profile": "Bakery"}
+    mock_server_hall = {"Type": "HeatProducerAgent", "Name": "HPA", "Profile": "Server hall"}
     mock_pv = {"Type": "BlockAgent",
                "Name": "PVParkAgent",
                "Atemp": 0.0,
@@ -149,8 +149,8 @@ class TestAppFunctions(TestCase):
 
     def test_heat_producer_agent_screening(self):
         """Test that we catch when an un-supported profile is specified for a HeatProducerAgent"""
-        agents = [self.mock_grid_el, self.mock_grid_he, self.mock_pv, self.mock_bakery]
-        self.assertEqual("Unrecognized Profile: Bakery, needs to be one of ['Grocery store']",
+        agents = [self.mock_grid_el, self.mock_grid_he, self.mock_pv, self.mock_server_hall]
+        self.assertEqual("Unrecognized Profile: Server hall, needs to be one of ['Grocery store', 'Bakery']",
                          config_data_agent_screening({'Agents': agents}))
 
     def test_config_naming_is_valid(self):

--- a/tradingplatformpoc/config/agents_specs.json
+++ b/tradingplatformpoc/config/agents_specs.json
@@ -208,7 +208,7 @@
     "HeatProducerAgent": {
         "Profile": {
             "help": "The profile of the heat producer. Determines what type (low/high-temp) of heating which is produced, and when it is produced (time of day, weekdays, seasonal effects etc)",
-            "options": ["Grocery store"],
+            "options": ["Grocery store", "Bakery"],
             "default_value": "Grocery store"
         },
         "Scale": {

--- a/tradingplatformpoc/digitaltwin/static_digital_twin.py
+++ b/tradingplatformpoc/digitaltwin/static_digital_twin.py
@@ -83,3 +83,15 @@ class StaticDigitalTwin:
         else:
             logger.warning("No usage defined for resource {}".format(resource))
             return 0
+
+    def can_sell_high_temp_heat(self):
+        """
+        Returns True if and only if:
+        * There _is_ high-temp heat production
+        * There _is not_ low-temp heat production
+        """
+        if self.hot_water_production is None or self.hot_water_production.eq(0).all():
+            return False
+        if self.space_heating_production is None or self.space_heating_production.eq(0).all():
+            return True
+        return False

--- a/tradingplatformpoc/generate_data/generation_functions/non_residential/heat_generation.py
+++ b/tradingplatformpoc/generate_data/generation_functions/non_residential/heat_generation.py
@@ -62,9 +62,9 @@ def _scale_grocery_store_heat_production(unscaled: pd.Series, scale_factor_from_
 
 def _get_bakery_hourly_factor(timestamp: datetime.datetime) -> float:
     """
-    10 hours per day, as specified by BDAB ('docs/Heat production.md')
+    10 hours per day, closed on weekends, as specified by BDAB ('docs/Heat production.md')
     """
-    if 3 <= timestamp.hour < 13:
+    if (3 <= timestamp.hour < 13) and timestamp.weekday() < 5:
         return 1.0
     return 0.0
 

--- a/tradingplatformpoc/simulation_runner/chalmers/CEMS_function.py
+++ b/tradingplatformpoc/simulation_runner/chalmers/CEMS_function.py
@@ -314,7 +314,7 @@ def max_Psell_grid(model, i, t):
 def max_Hsell_grid_winter(model, i, t):
     # Only used in winter mode : Due to high temperature of district heating (60 deg. C),
     # it is not possible to export heat from building to the district heating
-    return model.Hsell_grid[i, t] <= 0
+    return model.Hsell_grid[i, t] <= 0  # TODO: Bakery needs to be allowed to sell...
 
 
 def max_Hsell_grid_summer(model, i, t):
@@ -393,12 +393,12 @@ def agent_Hbalance_summer(model, i, t):
     # Only used in summer mode
     # with TES
     if model.kwh_per_deg[i] != 0:
-        return model.Hbuy_grid[i, t] + model.Hhp[i, t] \
+        return model.Hbuy_grid[i, t] + model.Hhp[i, t] + model.Hsh_excess_high_temp[i, t] \
             + model.Hsh_excess_low_temp[i, t] == model.Hsell_grid[i, t] + model.Hcha_shallow[i, t] \
             + model.Hsh[i, t] + PERC_OF_HT_COVERABLE_BY_LT * model.HTEScha[i, t] + model.heat_dump[i, t]
     # without TES
     else:
-        return model.Hbuy_grid[i, t] + model.Hhp[i, t] \
+        return model.Hbuy_grid[i, t] + model.Hhp[i, t] + model.Hsh_excess_high_temp[i, t] \
             + model.Hsh_excess_low_temp[i, t] == model.Hsell_grid[i, t] + model.Hcha_shallow[i, t] \
             + model.Hsh[i, t] + PERC_OF_HT_COVERABLE_BY_LT * model.Hhw[i, t] + model.heat_dump[i, t]
 

--- a/tradingplatformpoc/simulation_runner/chalmers/CEMS_function.py
+++ b/tradingplatformpoc/simulation_runner/chalmers/CEMS_function.py
@@ -19,6 +19,7 @@ def solve_model(solver: OptSolver, summer_mode: bool, month: int, n_agents: int,
                 booster_heatpump_max_heat: List[float], build_area: List[float], SOCTES0: List[float],
                 thermalstorage_max_temp: List[float], thermalstorage_volume: List[float], BITES_Eshallow0: List[float],
                 BITES_Edeep0: List[float], borehole: List[bool],
+                Hsell_grid_max: List[float], #TODO: Hsell_grid_max is Hmax_grid for bakery, otherwise it is 0
                 elec_consumption: pd.DataFrame, hot_water_heatdem: pd.DataFrame, space_heating_heatdem: pd.DataFrame,
                 cold_consumption: pd.DataFrame, pv_production: pd.DataFrame,
                 excess_low_temp_heat: pd.DataFrame, excess_high_temp_heat: pd.DataFrame,
@@ -123,6 +124,7 @@ def solve_model(solver: OptSolver, summer_mode: bool, month: int, n_agents: int,
     model.Hsh_excess_low_temp = pyo.Param(model.I, model.T, initialize=lambda m, i, t: excess_low_temp_heat.iloc[i, t])
     model.Hsh_excess_high_temp = pyo.Param(model.I, model.T,
                                            initialize=lambda m, i, t: excess_high_temp_heat.iloc[i, t])
+    model.Hsell_grid_max = pyo.Param(model.I, initialize=Hsell_grid_max)
     # BES data
     model.effe = pyo.Param(initialize=battery_efficiency)
     model.SOCBES0 = pyo.Param(model.I, initialize=SOCBES0)
@@ -314,7 +316,7 @@ def max_Psell_grid(model, i, t):
 def max_Hsell_grid_winter(model, i, t):
     # Only used in winter mode : Due to high temperature of district heating (60 deg. C),
     # it is not possible to export heat from building to the district heating
-    return model.Hsell_grid[i, t] <= 0  # TODO: Bakery needs to be allowed to sell...
+    return model.Hsell_grid[i, t] <=  model.Hsell_grid_max[i]
 
 
 def max_Hsell_grid_summer(model, i, t):

--- a/tradingplatformpoc/simulation_runner/chalmers/CEMS_function.py
+++ b/tradingplatformpoc/simulation_runner/chalmers/CEMS_function.py
@@ -19,7 +19,7 @@ def solve_model(solver: OptSolver, summer_mode: bool, month: int, n_agents: int,
                 booster_heatpump_max_heat: List[float], build_area: List[float], SOCTES0: List[float],
                 thermalstorage_max_temp: List[float], thermalstorage_volume: List[float], BITES_Eshallow0: List[float],
                 BITES_Edeep0: List[float], borehole: List[bool],
-                Hsell_grid_max: List[float], #TODO: Hsell_grid_max is Hmax_grid for bakery, otherwise it is 0
+                can_sell_high_temp_heat: List[bool],
                 elec_consumption: pd.DataFrame, hot_water_heatdem: pd.DataFrame, space_heating_heatdem: pd.DataFrame,
                 cold_consumption: pd.DataFrame, pv_production: pd.DataFrame,
                 excess_low_temp_heat: pd.DataFrame, excess_high_temp_heat: pd.DataFrame,
@@ -124,7 +124,7 @@ def solve_model(solver: OptSolver, summer_mode: bool, month: int, n_agents: int,
     model.Hsh_excess_low_temp = pyo.Param(model.I, model.T, initialize=lambda m, i, t: excess_low_temp_heat.iloc[i, t])
     model.Hsh_excess_high_temp = pyo.Param(model.I, model.T,
                                            initialize=lambda m, i, t: excess_high_temp_heat.iloc[i, t])
-    model.Hsell_grid_max = pyo.Param(model.I, initialize=Hsell_grid_max)
+    model.can_sell_high_temp_heat = pyo.Param(model.I, initialize=lambda m, i: can_sell_high_temp_heat[i])
     # BES data
     model.effe = pyo.Param(initialize=battery_efficiency)
     model.SOCBES0 = pyo.Param(model.I, initialize=SOCBES0)
@@ -314,14 +314,13 @@ def max_Psell_grid(model, i, t):
 
 
 def max_Hsell_grid_winter(model, i, t):
-    # Only used in winter mode : Due to high temperature of district heating (60 deg. C),
-    # it is not possible to export heat from building to the district heating
-    return model.Hsell_grid[i, t] <=  model.Hsell_grid_max[i]
+    # Only used in winter mode: Due to high temperature of the grid (60 deg. C), not all agents can export heat
+    return model.Hsell_grid[i, t] <= (1 * model.can_sell_high_temp_heat[i]) * model.Hmax_grid
 
 
 def max_Hsell_grid_summer(model, i, t):
     # Only used in summer mode
-    return model.Hsell_grid[i, t] <= model.Hmax_grid  # * (1 - model.U_heat_buy_sell_grid[i, t])
+    return model.Hsell_grid[i, t] <= model.Hmax_grid
 
 
 # Buying and selling power from the market cannot happen at the same time

--- a/tradingplatformpoc/simulation_runner/chalmers_interface.py
+++ b/tradingplatformpoc/simulation_runner/chalmers_interface.py
@@ -121,6 +121,7 @@ def optimize(solver: OptSolver, block_agents: List[BlockAgent], grid_agents: Dic
                 heatpump_max_heat=heatpump_max_heat,
                 HP_Cproduct_active=hp_produce_cooling,
                 borehole=hp_produce_cooling,
+                Hsell_grid_max=[0 for i in range(n_agents)],  # TODO: it should be calculated
                 booster_heatpump_COP=[area_info['COPBoosterPumps']] * n_agents,
                 booster_heatpump_max_power=booster_max_power,
                 booster_heatpump_max_heat=booster_max_heat,

--- a/tradingplatformpoc/simulation_runner/chalmers_interface.py
+++ b/tradingplatformpoc/simulation_runner/chalmers_interface.py
@@ -95,6 +95,7 @@ def optimize(solver: OptSolver, block_agents: List[BlockAgent], grid_agents: Dic
                              for agent in agent_guids]
     deep_storage_start = [(deep_storage_start_dict[agent] if agent in shallow_storage_start_dict.keys() else 0.0)
                           for agent in agent_guids]
+    can_sell_high_temp_heat = [agent.digital_twin.can_sell_high_temp_heat() for agent in block_agents]
 
     nordpool_prices: pd.Series = elec_pricing.get_nordpool_price_for_periods(start_datetime, trading_horizon)
     nordpool_prices = nordpool_prices.reset_index(drop=True)
@@ -121,7 +122,7 @@ def optimize(solver: OptSolver, block_agents: List[BlockAgent], grid_agents: Dic
                 heatpump_max_heat=heatpump_max_heat,
                 HP_Cproduct_active=hp_produce_cooling,
                 borehole=hp_produce_cooling,
-                Hsell_grid_max=[0 for i in range(n_agents)],  # TODO: it should be calculated
+                can_sell_high_temp_heat=can_sell_high_temp_heat,
                 booster_heatpump_COP=[area_info['COPBoosterPumps']] * n_agents,
                 booster_heatpump_max_power=booster_max_power,
                 booster_heatpump_max_heat=booster_max_heat,


### PR DESCRIPTION
Started enabling "Bakery" profile, but realized that the "max_Hsell_grid_winter" rule in CEMS_function.py currently stops it from working: This rule stops all selling of heat from internal agents during winter.

To get around this, we may need to further split up the logic for low- and high-temperature heat... What do you think @mrezamazidi, would this become tricky? Do you want to continue to take a look at this?